### PR TITLE
Execute command to set OIDC Settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.11
 
 RUN apk add --no-cache curl jq
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,27 @@ files:
 ```
 
 It will create or overwrite the pod security policy `restricted` even if cluster is upgraded.
+
+
+```yaml
+command:
+  - sh
+  - -c
+  - |
+    APIMANIFEST=/manifests/k8s-api-server.yaml
+    ISSUERURL=https://test.com
+    CLIENTID=123123
+    CLAIM=email
+    if ! grep -q oidc-client-id $APIMANIFEST; then
+      echo "OIDC Settings not present, applying"
+      echo "Previous API yaml"
+      cat $APIMANIFEST
+      awk '/feature-gates/ { print; print "    - --oidc-issuer-url=$ISSUERURL\n    - --oidc-client-id=$CLIENTID\n    - --oidc-username-claim=$CLAIM"; next }1' $APIMANIFEST > /tmp/tmp_api.yaml
+      mv /tmp/tmp_api.yaml $APIMANIFEST
+      echo "New api yaml:"
+      cat $APIMANIFEST
+    else
+      echo "OIDC Settings present"
+    fi
+```
+This will set the OIDC settings of a cluster. If available please use the CR to set OIDC, only use this as a las resource.

--- a/helm/k8s-initiator-app/Chart.yaml
+++ b/helm/k8s-initiator-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.2.0"
+appVersion: "v0.3.0"
 home: https://github.com/giantswarm/k8s-initiator-app
 description: The k8s initiator runs in master and apply some configuration when master is new.
 engine: gotpl

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -20,7 +20,7 @@ spec:
         releasetime: {{ $.Release.Time }}
     spec:
       tolerations:
-      # Run only master 
+      # Run only master
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/master
@@ -31,6 +31,15 @@ spec:
       - name: pause
         image: gcr.io/google_containers/pause-amd64:3.0
       initContainers:
+      - name: bash-initiator
+        image: quay.io/giantswarm/k8s-initiator:{{ .Chart.Version }}
+        command: {{ .Values.command }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+        - name: manifests-volume
+          mountPath: /manifests
       - name: k8s-initiator
         image: quay.io/giantswarm/k8s-initiator:{{ .Chart.Version }}
         volumeMounts:
@@ -40,3 +49,6 @@ spec:
       - name: config
         configMap:
           name: {{ template "initiator.fullname" . }}
+      - name: manifests-volume
+        hostPath:
+          path: /etc/kubernetes/manifests

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -33,7 +33,8 @@ spec:
       initContainers:
       - name: bash-initiator
         image: quay.io/giantswarm/k8s-initiator:{{ .Chart.Version }}
-        command: {{ .Values.command }}
+        command:
+{{ toYaml .Values.command | indent 10 }}
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/helm/k8s-initiator-app/templates/psp.yaml
+++ b/helm/k8s-initiator-app/templates/psp.yaml
@@ -19,6 +19,7 @@ spec:
   volumes:
     - 'configMap'
     - 'secret'
+    - 'hostPath'
   allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false
@@ -36,7 +37,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "initiator.fullname" . }}
   namespace: {{ .Release.Namespace }}
---- 
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/k8s-initiator-app/values.yaml
+++ b/helm/k8s-initiator-app/values.yaml
@@ -1,3 +1,8 @@
 files:
 - |
   ---
+command:
+  - sh
+  - -c
+  - |
+    echo "No command set"


### PR DESCRIPTION
Adding a values file with a command like the following would set the OIDC settings automatically:

```
command:
  - sh
  - -c
  - |
    APIMANIFEST=/manifests/k8s-api-server.yaml
    ISSUERURL=https://test.com
    CLIENTID=123123
    CLAIM=email
    if ! grep -q oidc-client-id $APIMANIFEST; then
      echo "OIDC Settings not present, applying"
      echo "Previous API yaml"
      cat $APIMANIFEST
      awk '/feature-gates/ { print; print "    - --oidc-issuer-url=$ISSUERURL\n    - --oidc-client-id=$CLIENTID\n    - --oidc-username-claim=$CLAIM"; next }1' $APIMANIFEST > /tmp/tmp_api.yaml
      mv /tmp/tmp_api.yaml $APIMANIFEST
      echo "New api yaml:"
      cat $APIMANIFEST
    else
      echo "OIDC Settings present"
    fi
```