### PR TITLE
Add ability to run on worker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # k8s-initiator-app
 
-An application that runs as daemonset only in the master nodes to maintain the state of some Kubernetes resources through cluster upgrades or master replacements.
+An application that runs as daemonset only in the master nodes (by default) to maintain the state of some Kubernetes resources through cluster upgrades or master replacements.
 
 As an example to persist a Pod Security Policy you can provide this values configuration at installation time it will create or overwrite the pod security policy `restricted` even if cluster is upgraded:
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ files:
     - projected
 ```
 
+It will create or overwrite the pod security policy `restricted` even if cluster is upgraded.
 
 
 This will set the OIDC settings of a cluster. If available please use the CR to set OIDC, only use this as a last resource.

--- a/helm/k8s-initiator-app/templates/_helpers.tpl
+++ b/helm/k8s-initiator-app/templates/_helpers.tpl
@@ -18,3 +18,35 @@
 {{- define "initiator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "initiator.nodeSelector" -}}
+{{- if .Values.masterOnly -}}
+tolerations:
+- effect: NoSchedule
+  operator: "Exists"
+  key: node-role.kubernetes.io/master
+nodeSelector:
+  kubernetes.io/role: master
+{{- else if .Values.nodeSelector }}
+nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 2 }}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "initiator.extraVolumes" -}}
+{{- range .Values.extraHostPaths }}
+- name: {{ .name }}
+  hostPath:
+    path: {{ .hostPath }}
+{{- end }}
+{{- end -}}
+
+{{- define "initiator.extraVolumeMounts" -}}
+{{- range .Values.extraHostPaths }}
+- name: {{ .name }}
+  mountPath: {{ .mountPath }}
+{{- end }}
+{{- end -}}
+
+

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -19,18 +19,13 @@ spec:
       annotations:
         releasetime: {{ now | quote }}
     spec:
-      tolerations:
-      # Run only master
-      - effect: NoSchedule
-        operator: "Exists"
-        key: node-role.kubernetes.io/master
-      nodeSelector:
-        kubernetes.io/role: master
+{{ include "initiator.nodeSelector" . | indent 6 }}
       serviceAccountName: {{ template "initiator.fullname" . }}
       containers:
       - name: pause
         image: gcr.io/google_containers/pause-amd64:3.0
       initContainers:
+{{ if has "bash" .Values.initiators }}
       - name: bash-initiator
         image: quay.io/giantswarm/k8s-initiator:{{ .Chart.Version }}
         command:
@@ -41,11 +36,16 @@ spec:
         volumeMounts:
         - name: manifests-volume
           mountPath: /manifests
+{{- include "initiator.extraVolumeMounts" . | indent 8 -}}
+{{ end }}
+{{ if has "k8s" .Values.initiators }}
       - name: k8s-initiator
         image: quay.io/giantswarm/k8s-initiator:{{ .Chart.Version }}
         volumeMounts:
         - name: config
           mountPath: /etc/k8s-initiator
+{{- include "initiator.extraVolumeMounts" . | indent 8 -}}
+{{ end }}
       volumes:
       - name: config
         configMap:
@@ -53,3 +53,4 @@ spec:
       - name: manifests-volume
         hostPath:
           path: /etc/kubernetes/manifests
+{{- include "initiator.extraVolumes" . | indent 6 }}

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: {{ template "initiator.fullname" . }}
       annotations:
-        releasetime: {{ $.Release.Time }}
+        releasetime: {{ now | quote }}
     spec:
       tolerations:
       # Run only master

--- a/helm/k8s-initiator-app/templates/psp.yaml
+++ b/helm/k8s-initiator-app/templates/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: {{ template "initiator.fullname" . }}
 spec:
-  privileged: false
+  privileged: {{ .Values.psp.privileged }}
   fsGroup:
     rule: RunAsAny
   runAsUser:

--- a/helm/k8s-initiator-app/templates/rbac.yaml
+++ b/helm/k8s-initiator-app/templates/rbac.yaml
@@ -15,12 +15,21 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "initiator.fullname" . }}
   namespace: {{ .Release.Namespace }}
---- 
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "initiator.fullname" . }}
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+  - patch
+  - get
+  - list
 - apiGroups:
   - extensions
   resources:

--- a/helm/k8s-initiator-app/values.yaml
+++ b/helm/k8s-initiator-app/values.yaml
@@ -6,3 +6,12 @@ command:
   - -c
   - |
     echo "No command set"
+
+psp:
+  privileged: false
+masterOnly: true
+nodeSelector: {}
+initiators:
+  - bash
+  - k8s
+extraHostPaths: []


### PR DESCRIPTION
This is towards https://github.com/giantswarm/vodafone-iot-ocs/issues/3

For openet software to run on VF cluster, `sysfs` settings need to be
applied
(also node labels). Using this app makes it easy to keep these settings
after cluster upgrade etc.

This commit also introduces the ability to enable/disable the initiators,
so in cases like VF, only the bash initiator runs.

If you run only on workers, you can further refine by using a node
selector, so it should be possible to target nodepools.

`extraHostPaths[]` allows mounting of `sysfs` as this is normally readonly
inside the container.

Sample values file that can be used:

``` 
command:
  - sh
  - -c
  - |
    grep -q '\[never\]' /sys/kernel/mm/transparent_hugepage/enabled || echo never > /sys/kernel/mm/transparent_hugepage/enabled
    grep -q '\[never\]' /sys/kernel/mm/transparent_hugepage/defrag || echo never > /sys/kernel/mm/transparent_hugepage/defrag
    echo "Current setting of /sys/kernel/mm/transparent_hugepage/enabled"
    cat /sys/kernel/mm/transparent_hugepage/enabled
    echo "Current setting of /sys/kernel/mm/transparent_hugepage/defrag"
    cat /sys/kernel/mm/transparent_hugepage/defrag
    for i in `kubectl get nodes -l kubernetes.io/role=worker,transparent_hugepage!=disabled -o json | jq -r '.items[].metadata.name'`
    do
      kubectl label nodes $i transparent_hugepage=disabled
    done

masterOnly: false
nodeSelector:
  kubernetes.io/role: worker
initiators:
  - bash
extraHostPaths:
  - name: sysfs
    hostPath: /sys
    mountPath: /sys
```