### PR TITLE
Allow the user to use affinity

### DIFF
--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -21,6 +21,7 @@ spec:
     spec:
       priorityClassName: {{ .Values.priorityClassName }}
 {{ include "initiator.nodeSelector" . | indent 6 }}
+{{ include "initiator.affinity" . | indent 6 }}
       serviceAccountName: {{ template "initiator.fullname" . }}
       containers:
       - name: pause

--- a/helm/k8s-initiator-app/values.yaml
+++ b/helm/k8s-initiator-app/values.yaml
@@ -26,6 +26,7 @@ psp:
   privileged: false
 masterOnly: true
 nodeSelector: {}
+affinity: {}
 initiators:
   - bash
   - k8s


### PR DESCRIPTION
Given more fine grained control over where the app runs. This is useful if
multiple nodepools need the app (but not all).