### PR TITLE
Use hostNetwork (nodeIP) to preserve cluster IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added link to README under `sources:` to render README in Web UI
-- Support user specifying `tolerations` 
+- Support user specifying `tolerations`
+- Add `hostNetwork` and default to `true`
 
 ## [0.9.0] - 2020-10-01
 

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         releasetime: {{ now | quote }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{ include "initiator.nodeSelector" . | indent 6 }}
 {{ include "initiator.affinity" . | indent 6 }}

--- a/helm/k8s-initiator-app/templates/psp.yaml
+++ b/helm/k8s-initiator-app/templates/psp.yaml
@@ -21,7 +21,7 @@ spec:
     - 'secret'
     - 'hostPath'
   allowPrivilegeEscalation: false
-  hostNetwork: false
+  hostNetwork: {{ .Values.hostNetwork }}
   hostIPC: false
   hostPID: false
 ---

--- a/helm/k8s-initiator-app/values.yaml
+++ b/helm/k8s-initiator-app/values.yaml
@@ -25,6 +25,7 @@ priorityClassName: system-node-critical
 psp:
   privileged: false
 masterOnly: true
+hostNetwork: true
 nodeSelector: {}
 affinity: {}
 tolerations: {}


### PR DESCRIPTION
When using AWS CNI, the ip's become a bit more precious, so let's not use them
for k8s-initiator (as we don't need them at all).