### PR TITLE
Add ability to patch k8s resource

### DIFF
--- a/helm/k8s-initiator-app/templates/configmap.yaml
+++ b/helm/k8s-initiator-app/templates/configmap.yaml
@@ -8,3 +8,17 @@ data:
     ---
 {{ $file | indent 4 }}
 {{- end }}
+{{- if .Values.patches }}
+{{- $patchResources := list }}
+{{- range .Values.patches }}
+{{- $jsonPatch := toJson .patch }}
+{{- $ns := .namespace | default "default" }}
+{{- $cmdOptions := printf "%s -n %s -p '%s'" .resource $ns $jsonPatch }}
+{{- $patchResources = append $patchResources $cmdOptions }}
+{{- end }}
+  k8s-patches.sh: |-
+    #!/bin/bash
+{{- range $patchResources }}
+    kubectl patch {{ . }}
+{{- end }}
+{{- end }}

--- a/helm/k8s-initiator-app/values.yaml
+++ b/helm/k8s-initiator-app/values.yaml
@@ -7,6 +7,8 @@ command:
   - |
     echo "No command set"
 
+patches: []
+
 image:
   registry: quay.io
   k8sInitiatorContainerImage:

--- a/run.sh
+++ b/run.sh
@@ -3,3 +3,5 @@
 echo "Executing commands..."
 
 kubectl apply -f /etc/k8s-initiator/resources.yaml
+
+[ -f /etc/k8s-initiator/k8s-patches.sh ] && . /etc/k8s-initiator/k8s-patches.sh


### PR DESCRIPTION
Update the configmap to create a script that can be run and patch k8s resources.
The use case that is motivating this commit, is being able to patch resources
that usually are not easily configurable. The actual situation is updating AWS CNI
environment variables (change MTU size).