### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,53 +1,26 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.34.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
     jobs:
-      - architect/push-to-docker:
-          name: push-k8s-initiator-to-quay
-          image: "quay.io/giantswarm/k8s-initiator"
+      - architect/push-to-registries:
           context: architect
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
-          # Needed to trigger job also on git tag.
+          name: push-to-registries
+          requires:
+            - hold-push-k8s-initiator-to-aliyun-pr
           filters:
             tags:
               only: /^v.*/
 
+          image: giantswarm/k8s-initiator
       - hold-push-k8s-initiator-to-aliyun-pr:
           type: approval
           # Needed to prevent job from being triggered on master branch.
           filters:
             branches:
               ignore: master
-
-      - architect/push-to-docker:
-          name: push-k8s-initiator-to-aliyun-pr
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/k8s-initiator"
-          context: architect
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          # Push to Aliyun should execute for non-master branches only once manually approved.
-          requires:
-            - hold-push-k8s-initiator-to-aliyun-pr
-          # Needed to prevent job being triggered for master branch.
-          filters:
-            branches:
-              ignore: master
-
-      # Push to Aliyun should execute without manual approval on master.
-      - architect/push-to-docker:
-          name: push-k8s-initiator-to-aliyun-master
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/k8s-initiator"
-          context: architect
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          # Needed to trigger job only on merge to master.
-          filters:
-            branches:
-              only: master
 
       - architect/push-to-app-catalog:
           name: "package and push k8s-initiator-app chart"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ workflows:
           context: architect
           name: push-to-registries
           image: giantswarm/k8s-initiator
-          requires:
-            - hold-push-k8s-initiator-to-aliyun-pr
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,12 @@ workflows:
       - architect/push-to-registries:
           context: architect
           name: push-to-registries
+          image: giantswarm/k8s-initiator
           requires:
             - hold-push-k8s-initiator-to-aliyun-pr
           filters:
             tags:
               only: /^v.*/
-
-          image: giantswarm/k8s-initiator
-      - hold-push-k8s-initiator-to-aliyun-pr:
-          type: approval
-          # Needed to prevent job from being triggered on master branch.
-          filters:
-            branches:
-              ignore: master
 
       - architect/push-to-app-catalog:
           name: "package and push k8s-initiator-app chart"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!