### PR TITLE
Allow privileged daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow privileged pods
+
 ## [0.10.0] - 2024-09-11
 
 ###  Changed

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -23,7 +23,6 @@ spec:
       hostIPC: {{ .Values.hostIPC }}
       hostPID: {{ .Values.hostPID }}
       priorityClassName: {{ .Values.priorityClassName }}
-      privileged: {{ .Values.privileged }}
 {{ include "initiator.nodeSelector" . | indent 6 }}
 {{ include "initiator.affinity" . | indent 6 }}
 {{ include "initiator.tolerations" . | indent 6 }}
@@ -42,6 +41,7 @@ spec:
         securityContext:
           runAsUser: 0
           runAsGroup: 0
+          privileged: {{ .Values.privileged }}
         volumeMounts:
         - name: manifests-volume
           mountPath: /manifests

--- a/helm/k8s-initiator-app/templates/daemonsets.yaml
+++ b/helm/k8s-initiator-app/templates/daemonsets.yaml
@@ -23,6 +23,7 @@ spec:
       hostIPC: {{ .Values.hostIPC }}
       hostPID: {{ .Values.hostPID }}
       priorityClassName: {{ .Values.priorityClassName }}
+      privileged: {{ .Values.privileged }}
 {{ include "initiator.nodeSelector" . | indent 6 }}
 {{ include "initiator.affinity" . | indent 6 }}
 {{ include "initiator.tolerations" . | indent 6 }}

--- a/helm/k8s-initiator-app/templates/policy-exception.yaml
+++ b/helm/k8s-initiator-app/templates/policy-exception.yaml
@@ -43,6 +43,10 @@ spec:
       ruleNames:
         - autogen-restricted-volumes
         - restricted-volumes
+    - policyName: disallow-privileged-containers
+      ruleNames:
+        - autogen-privileged-containers
+        - privileged-containers
   match:
     any:
       - resources:

--- a/helm/k8s-initiator-app/values.yaml
+++ b/helm/k8s-initiator-app/values.yaml
@@ -43,6 +43,8 @@ nodeSelector: {}
 # Make room to run the pod
 priorityClassName: system-node-critical
 
+privileged: false
+
 psp:
   privileged: false
   ipc: false


### PR DESCRIPTION
https://gigantic.slack.com/archives/C062HB29BDG/p1726224168298689

We still need this app to configure some kernel parameters which is not possible without the privileged context in vintage.